### PR TITLE
Travisci fix erroneous rust builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,7 @@ jobs:
             aws s3 cp www/dist/0.bootstrap.js s3://bigprimes/ && echo 'S3 js sync complete.'
             aws s3 cp www/*.css               s3://bigprimes/ && echo 'S3 css sync complete.'
             aws s3 cp www/favicon.ico         s3://bigprimes/ && echo 'S3 favicon sync complete.'
-            aws s3 cp www/robots.txt         s3://bigprimes/ && echo 'S3 robots.txt sync complete.'
+            aws s3 cp www/robots.txt          s3://bigprimes/ && echo 'S3 robots.txt sync complete.'
             aws cloudfront create-invalidation --distribution-id $AWS_CF_DISTRIBUTION_ID --paths "/*" && echo 'CloudFront cache invalidated.'
           fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache:
   cargo: true
   pip: true
 
+env: RUST_BACKTRACE=1
+
 os: linux
 
 stages:
@@ -19,7 +21,6 @@ jobs:
     - stage: Tests
     # Builds on nightly.
     - rust: nightly
-      env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -48,7 +49,6 @@ jobs:
         - cargo test
     # Builds on beta.
     - rust: beta
-      env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -76,7 +76,6 @@ jobs:
         - cargo test
     # Builds on stable.
     - rust: stable
-      env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -104,7 +103,6 @@ jobs:
         - cargo test
     - stage: PR CodeCov
     - rust: nightly
-      env: RUST_BACKTRACE=1
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip
@@ -136,7 +134,6 @@ jobs:
     
     - stage: Deploy
     - rust: nightly
-      env: RUST_BACKTRACE=1
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,6 @@ jobs:
             aws s3 cp www/*.css               s3://bigprimes/ && echo 'S3 css sync complete.'
             aws s3 cp www/favicon.ico         s3://bigprimes/ && echo 'S3 favicon sync complete.'
             aws s3 cp www/robots.txt         s3://bigprimes/ && echo 'S3 robots.txt sync complete.'
-            #TODO: create and copy a favicon, currently cloudfront will serve the index.html as favicon!
             aws cloudfront create-invalidation --distribution-id $AWS_CF_DISTRIBUTION_ID --paths "/*" && echo 'CloudFront cache invalidated.'
           fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip
-        - sudo pip install awscli
+        - sudo -H $HOME pip install awscli
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   include:
     - stage: Tests
     # Builds on nightly.
-    - rust: nightly
+      rust: nightly
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -48,7 +48,8 @@ jobs:
         - cargo build
         - cargo test
     # Builds on beta.
-    - rust: beta
+    - 
+      rust: beta
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -75,7 +76,8 @@ jobs:
         - cargo build
         - cargo test
     # Builds on stable.
-    - rust: stable
+    -
+      rust: stable
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true
@@ -102,7 +104,7 @@ jobs:
         - cargo build
         - cargo test
     - stage: PR CodeCov
-    - rust: nightly
+      rust: nightly
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip
@@ -133,7 +135,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f lcov.info;
     
     - stage: Deploy
-    - rust: nightly
+      rust: nightly
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ jobs:
       before_install:
         #todo: Can these package installs be cached?
         - sudo apt-get install python python-pip
-        - sudo pip install awscli
+        - sudo -H $HOME pip install awscli
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   include:
     - stage: Tests
     # Builds on nightly.
-      rust: nightly
+    - rust: nightly
       env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
@@ -47,7 +47,7 @@ jobs:
         - cargo build
         - cargo test
     # Builds on beta.
-      rust: beta
+    - rust: beta
       env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
@@ -75,7 +75,7 @@ jobs:
         - cargo build
         - cargo test
     # Builds on stable.
-      rust: stable
+    - rust: stable
       env: RUST_BACKTRACE=1
       install:
         # If caching is working then this binary will already be installed, and this throws an error
@@ -103,7 +103,7 @@ jobs:
         - cargo build
         - cargo test
     - stage: PR CodeCov
-      rust: nightly
+    - rust: nightly
       env: RUST_BACKTRACE=1
       before_install:
         #todo: Can these package installs be cached?
@@ -135,7 +135,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f lcov.info;
     
     - stage: Deploy
-      rust: nightly
+    - rust: nightly
       env: RUST_BACKTRACE=1
       before_install:
         #todo: Can these package installs be cached?

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,8 +156,6 @@ jobs:
         - rm -rfv $TRAVIS_BUILD_DIR/target/debug/{big_primes,libbig_primes}.d
         - cargo clean -p big_primes
       script:
-        - export CARGO_INCREMENTAL=0
-        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
         - cargo build
         - cargo test
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,10 +105,6 @@ jobs:
         - cargo test
     - stage: PR CodeCov
       rust: nightly
-      before_install:
-        #todo: Can these package installs be cached?
-        - sudo apt-get install python python-pip
-        - sudo -H $HOME pip install awscli
       install:
         # If caching is working then this binary will already be installed, and this throws an error
         # We prevent the error from stopping travisci via || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache:
   cargo: true
   pip: true
 
+os: linux
+
 stages:
   - name: Tests
     if: type = pull_request
@@ -16,7 +18,6 @@ jobs:
   include:
     - stage: Tests
     # Builds on nightly.
-    - os: linux
       rust: nightly
       env: RUST_BACKTRACE=1
       install:
@@ -46,7 +47,6 @@ jobs:
         - cargo build
         - cargo test
     # Builds on beta.
-    - os: linux
       rust: beta
       env: RUST_BACKTRACE=1
       install:
@@ -75,7 +75,6 @@ jobs:
         - cargo build
         - cargo test
     # Builds on stable.
-    - os: linux
       rust: stable
       env: RUST_BACKTRACE=1
       install:
@@ -104,7 +103,6 @@ jobs:
         - cargo build
         - cargo test
     - stage: PR CodeCov
-    - os: linux
       rust: nightly
       env: RUST_BACKTRACE=1
       before_install:
@@ -137,7 +135,6 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f lcov.info;
     
     - stage: Deploy
-    - os: linux
       rust: nightly
       env: RUST_BACKTRACE=1
       before_install:


### PR DESCRIPTION
 - Remove completed todo
 - Remove unwanted extra builds on each stage (fixed by correcting syntax!)
 - Move duplicate lines out of jobs list, e.g. the os, env.
 - Removed package installs from codecov stage/job
 - Likely fixed caching for pip on deploy stage (Will need to deploy to test!) using `sudo -H $HOME`