### PR TITLE
Removed "cargo test" from deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,6 @@ jobs:
         - cargo clean -p big_primes
       script:
         - cargo build
-        - cargo test
       after_success:
         - |
           if([ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ])


### PR DESCRIPTION
There is no need to run cargo test when our CI rules already require various status checks to be true before merge is allowed. The unit tests are already run on 3 versions of rust as part of a status check.