### PR TITLE
Fix apex domain redirect to www

### DIFF
--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -45,21 +45,71 @@ Resources:
         - Key: application
           Value: bigprimes.net
 
+  RedirectCloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Origins:
+        - DomainName: !GetAtt 'RedirectS3Bucket.RegionalDomainName'
+          Id: bigprimesCustomOrigin
+          S3OriginConfig:
+            OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${RedirectCloudFrontOriginAccessIdentity}'
+        Enabled: 'true'
+        Comment: bigprimes.net redirect
+        DefaultRootObject: index.html
+        Aliases:
+        - "bigprimes.net"
+        HttpVersion: http2
+        DefaultCacheBehavior:
+          Compress: 'true'
+          TargetOriginId: bigprimesCustomOrigin
+          SmoothStreaming: 'false'
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: all
+          ViewerProtocolPolicy: redirect-to-https
+        PriceClass: PriceClass_100
+        ViewerCertificate:
+          AcmCertificateArn: !Ref ParamCertificateARN
+          MinimumProtocolVersion: TLSv1.1_2016
+          SslSupportMethod: sni-only
+      Tags:
+        - Key: application
+          Value: bigprimes.net
+
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
     Properties:
       CloudFrontOriginAccessIdentityConfig:
         Comment: !Ref S3Bucket
 
+  RedirectCloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Ref RedirectS3Bucket
+
   WWWDNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: bigprimes.net.
-      Comment: Bigprimes API
+      Comment: Bigprimes
       Name: "www.bigprimes.net"
       Type: CNAME
       TTL: '300'
       ResourceRecords: [!GetAtt 'CloudFrontDistribution.DomainName']
+
+  ApexDNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        HostedZoneId: Z2FDTNDATAQYW2 #curiously this hardcoded value is recommened by AWS documentation
+        DNSName: !GetAtt 'RedirectCloudFrontDistribution.DomainName'
+      HostedZoneName: bigprimes.net.
+      Comment: Bigprimes
+      Name: "bigprimes.net"
+      Type: A
 
   S3Bucket:
     Type: AWS::S3::Bucket
@@ -97,7 +147,7 @@ Resources:
           Resource: !Sub 'arn:aws:s3:::${S3Bucket}/*'
           Principal:
             CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-            
+
   RedirectS3Bucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -97,6 +97,31 @@ Resources:
           Resource: !Sub 'arn:aws:s3:::${S3Bucket}/*'
           Principal:
             CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+            
+  RedirectS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: bigprimes-redirect
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        RedirectAllRequestsTo:
+          HostName: 'www.bigprimes.net'
+          Protocol: https
+    DeletionPolicy: Delete
+
+  RedirectBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref RedirectS3Bucket
+      PolicyDocument:
+        Id: MyPolicy
+        Version: 2012-10-17
+        Statement:
+          - Action: 's3:GetObject'
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${RedirectS3Bucket}/*'
+            Principal:
+              CanonicalUser: !GetAtt RedirectCloudFrontOriginAccessIdentity.S3CanonicalUserId
 
   PublishUser:
     Type: AWS::IAM::User

--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -51,7 +51,7 @@ Resources:
       CloudFrontOriginAccessIdentityConfig:
         Comment: !Ref S3Bucket
 
-  APIDNSRecord:
+  WWWDNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: bigprimes.net.

--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -50,13 +50,12 @@ Resources:
     Properties:
       DistributionConfig:
         Origins:
-        - DomainName: !GetAtt 'RedirectS3Bucket.RegionalDomainName'
+        - DomainName: !Sub bigprimes-redirect.s3-website-${AWS::Region}.amazonaws.com
           Id: bigprimesCustomOrigin
-          S3OriginConfig:
-            OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${RedirectCloudFrontOriginAccessIdentity}'
+          CustomOriginConfig:
+            OriginProtocolPolicy: http-only
         Enabled: 'true'
         Comment: bigprimes.net redirect
-        DefaultRootObject: index.html
         Aliases:
         - "bigprimes.net"
         HttpVersion: http2

--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -30,7 +30,7 @@ Resources:
             QueryString: 'false'
             Cookies:
               Forward: all
-          ViewerProtocolPolicy: allow-all
+          ViewerProtocolPolicy: redirect-to-https
         CustomErrorResponses:
         - ErrorCode: '404'
           ResponsePagePath: "/index.html"

--- a/aws-cloudformation.yaml
+++ b/aws-cloudformation.yaml
@@ -86,7 +86,7 @@ Resources:
             Resource:
               - !Sub 'arn:aws:s3:::${S3Bucket}/*'
 
-  ReadPolicy:
+  S3BucketReadPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref S3Bucket


### PR DESCRIPTION
Now works for both http and https. Correctly redirects any page on bigprimes.net to www.bigprimes.net