### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Add an explicit top-level `permissions` block in `.github/workflows/rust.yml` so all jobs inherit minimal required token scope.

Best fix (without changing behavior):  
- Insert at workflow root (after `on:` block and before `env:` is a clean location):
  - `permissions:`
  - `  contents: read`

Why this is best:
- All three jobs (`lint`, `test`, `bench`) need repository read access for checkout.
- No step requires writing to issues, PRs, packages, or contents.
- A single root-level block avoids duplication and keeps intent documented.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
